### PR TITLE
Validation passed bugfix

### DIFF
--- a/lib/validate/index.js
+++ b/lib/validate/index.js
@@ -20,10 +20,11 @@ module.exports = function validateHook (schema, options) {
     var validate = validator(schema, options)
     var valid = validate(hook.data)
 
-    let data = hook.data
-    data.errors = validate.errors.map(errorsMap)
-
-    if (!valid) throw new errors.BadRequest('Validation failed', data)
+    if (!valid) {
+      let data = hook.data
+      data.errors = validate.errors.map(errorsMap)
+      throw new errors.BadRequest('Validation failed', data)
+    }
   }
 }
 


### PR DESCRIPTION
The hook was throwing a 500 error for valid data.

That's because `validate.errors` doesnt get defined for valid json, this might have changed on recent versions of `is-my-json-valid`.
